### PR TITLE
docker-compose.yaml: add port map for default maridb container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       - ratbot
     networks:
       - ratbot
+    ports:
+      - 127.0.0.1:3306:3306/tcp
     volumes:
       - db_data:/var/lib/mysql
     env_file: ./.mysql.env


### PR DESCRIPTION
 (127.0.0.1:3306:3306/tcp - loopback, default port)